### PR TITLE
fixing redownload bug

### DIFF
--- a/XMLDownload.py
+++ b/XMLDownload.py
@@ -105,7 +105,6 @@ def handleRSS(rss, db, cache, files):
                 sys.stdout.flush()
                 urllib.urlretrieve(link, "{}/{}.torrent".format(files, id))
                 logging.debug("- Download finished.")
-                new_database.append(id)
             except urllib2.HTTPError, e:
                 logging.error("Error while downloading {} from link: {} HTTPError = {}".format(id,
                                                                                                link,
@@ -119,8 +118,9 @@ def handleRSS(rss, db, cache, files):
                 logging.error('generic exception: ' + traceback.format_exc())
                 logging.error("Error while downloading {} from link: {}".format(id,link))
 
-    try:
+        new_database.append(id)
 
+    try:
         with open(db, 'w') as f:
             for item in new_database:
                 f.write("%s\n" % item)

--- a/XMLDownload.py
+++ b/XMLDownload.py
@@ -47,6 +47,14 @@ def parseRSS(content):
         logging.error("Problem with parsing RSS content.")
     return return_value
 
+def fetchRSS(rss):
+    try:
+        response = urllib2.urlopen(rss)
+        rss_content = response.read()
+    except urllib2.URLError as e:
+        raise e
+
+    return rss_content
 
 def handleRSS(rss, db, cache, files):
 
@@ -58,12 +66,8 @@ def handleRSS(rss, db, cache, files):
     except:
         old_file_size = 0
 
-    try:
-        response = urllib2.urlopen(rss)
-        rss_content = response.read()
-        new_file_size = len(rss_content)
-    except urllib2.URLError as e:
-        raise e
+    rss_content = fetchRSS(rss)
+    new_file_size = len(rss_content)
 
     if new_file_size == old_file_size:
         logging.debug("Content size is the same as the last time. Skip the rest.")

--- a/XMLDownload.py
+++ b/XMLDownload.py
@@ -56,21 +56,25 @@ def fetchRSS(rss):
 
     return rss_content
 
-def handleRSS(rss, db, cache, files):
-
-    if (not os.path.isdir(files)):
-        raise OSError(files + " does not exists")
-
+def isSameRSS(rss_content, cache):
     try:
         old_file_size = os.stat(cache).st_size
     except:
         old_file_size = 0
 
-    rss_content = fetchRSS(rss)
     new_file_size = len(rss_content)
 
-    if new_file_size == old_file_size:
-        logging.debug("Content size is the same as the last time. Skip the rest.")
+    return new_file_size == old_file_size
+
+def handleRSS(rss, db, cache, files):
+
+    if (not os.path.isdir(files)):
+        raise OSError(files + " does not exists")
+
+    rss_content = fetchRSS(rss)
+
+    if isSameRSS(rss_content, cache):
+        logging.debug("RSS is the same. Skip the rest.")
         return
     else:
         try:


### PR DESCRIPTION
When rss changed, those IDs that were available both in the new rss and the db, were not written into the new db. As a result, when the rss changed again, those IDs were redownloaded. This patch fixes this bug.